### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "com.plugins.shortcut",
+  "version": "0.1.1",
+  "description": "<p>This is the plugin to create/delete Shortcuts (Android) in Apache Cordova/PhoneGap!</p><p>The Shortcut plugin for Apache Cordova allows you to create or delete the shortcut in the home of any andorid device.</p>",
+  "cordova": {
+    "id": "com.plugins.shortcut",
+    "platforms": [
+      "android"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jorgecis/ShortcutPlugin.git"
+  },
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -10,13 +10,24 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jorgecis/ShortcutPlugin.git"
+    "url": "git+https://github.com/jorgecis/ShortcutPlugin.git"
   },
+  "keywords": [
+    "cordova",
+    "shortcut",
+    "jorgecis",
+    "cordova-android"
+  ],
   "engines": [
     {
       "name": "cordova",
       "version": ">=3.0.0"
     }
   ],
-  "license": "MIT"
+  "author": "jorgecis",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jorgecis/ShortcutPlugin/issues"
+  },
+  "homepage": "https://github.com/jorgecis/ShortcutPlugin#readme"
 }


### PR DESCRIPTION
Platforms and plugins are now required to have a package.json file (see https://cordova.apache.org/blog/).